### PR TITLE
docs: 公開された Pages が実際に返すものを測った（M-94 §12）

### DIFF
--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -7208,7 +7208,7 @@ node /tmp/align.js
 - **`AudioContext` は 22,050 Hz を保証しない。** 出音は端末のサンプルレート（多くは 48,000 Hz）へ
   **リサンプルされる**ので、**鳴っている音は checksum と一致しない**。
   一致を主張してよいのは `saan_web_pcm()` が返す float 配列まで
-- **`.bin` に対する Pages の `Content-Encoding` は未確認**（§8）
+- ~~**`.bin` に対する Pages の `Content-Encoding` は未確認**~~ → ✅ **§12 で測った**（gzip が付く）
 - **wasm の転送サイズ・起動時間・初回描画までの時間を測っていない**
 - **`web/main.js` はどのゲートも 1 行も走らせていない**（§11）。
   `saan_web_message()` の表示を消しても全ゲートは緑のまま
@@ -7246,3 +7246,45 @@ git checkout -- web/saan_web.c
 G-W7 / G-W1 / G-W2 / G-W2b / G-W3 / G-W4 / G-W5 / G-W6。CI の `web` job でも回る。
 **辞書 13.7 MB が要る部分**（漢字 == かな / ids 350 超えの拒否）だけは CI で回らず、
 ⚠️ **skip ではなく「回せなかった」と理由つきで出る。**
+
+### 12. 公開された Pages が実際に返すもの（自己実測 / 2026-09-04）
+
+`main` にマージして [`pages.yml`](../.github/workflows/pages.yml) が初めて走った直後
+（run 33830594650。build / deploy とも success）に、**公開 URL を叩いて測った**。
+
+再現:
+
+```bash
+curl -sL -o /dev/null -w '%{http_code} %{content_type} %{size_download}\n' \
+     https://ayutaz.github.io/sanoTTS-jp/saan_web_w8a32.wasm
+# 転送時の圧縮を見るなら Accept-Encoding を付けてヘッダを読む
+curl -sL -o /dev/null -D - -H 'Accept-Encoding: gzip, deflate, br' \
+     https://ayutaz.github.io/sanoTTS-jp/student_i8.bin | grep -i content-encoding
+```
+
+| 資産 | HTTP | `content-type` | 非圧縮 | 転送時 |
+|---|---:|---|---:|---|
+| `index.html` | 200 | `text/html` | 13,502 | — |
+| `main.js` | 200 | `application/javascript` | 21,171 | — |
+| `saan_web_w8a32.mjs` | 200 | `text/javascript` | 9,893 | — |
+| `saan_web_w8a32.wasm` | 200 | **`application/wasm`** | 161,233 | **gzip** |
+| `saan_web_w8a8.wasm` | 200 | `application/wasm` | 162,793 | gzip |
+| `student_i8.bin` | 200 | `application/octet-stream` | 654,032 | **gzip** |
+| `k1_dict.bin.gz` | 200 | `application/gzip` | **5,496,167** | なし（既に gzip） |
+| `NOTICE*.txt` / `LICENSE-MODEL.md` | 200 | `text/plain` / `text/markdown` | — | — |
+
+⚠️ **陽性対照**: 在らざる名前（`saan_web_w8a99.mjs`）は **404**。
+「全部 200」がサーバの挙動ではないことを確かめてある。
+
+**分かったこと:**
+
+- ✅ **`.wasm` は `application/wasm` で返る** → `WebAssembly.instantiateStreaming` がそのまま使える
+- ✅ **`.bin`（`application/octet-stream`）にも Pages は gzip を掛ける。**
+  §10 で「未確認」としていた点。⚠️ **それでも辞書を `.gz` で置く判断は変えない** —
+  配信側の方針に依存させないため（方針は予告なく変わりうる）
+- ⚠️ **`k1_dict.bin.gz` は 5,496,167 B**。手元の `gzip -9`（5,476,122 B）より **20,045 B 大きい**。
+  ubuntu-latest の GNU gzip と macOS の Apple gzip の版差で、
+  **中身は同じ**（`pages.yml` が展開して `cmp` で確かめている）
+
+⚠️ **これは「配信されている」ことの確認であって、「ブラウザで動く」ことの確認ではない。**
+**ブラウザは 1 種類も開いていないし、音も誰も聴いていない**（§10 は埋まっていない）。

--- a/docs/plan/web-demo-plan.md
+++ b/docs/plan/web-demo-plan.md
@@ -152,7 +152,9 @@ G-W1/G-W2 が緑でも、**ブラウザが通る経路は 1 行も検査され�
     一致するのは `|max|` と `Σx²` の相対差だけ。
 13. **Pages は HTTP ヘッダを設定できない。** COOP/COEP が張れないので
     `-pthread` / `SharedArrayBuffer` は**構造的に使えない**。
-14. **`.bin` が Pages で gzip されるかは未確認。** だから `.gz` を置いて
+14. ~~**`.bin` が Pages で gzip されるかは未確認。**~~ → ✅ **公開して測ったら、gzip されると分かった**
+    （`student_i8.bin` は `application/octet-stream` で `content-encoding: gzip` が付く。M-94 §12）。
+    ⚠️ **それでも `.gz` を置く判断は変えない** — 配信側の方針に依存させないため。だから `.gz` を置いて
     `DecompressionStream('gzip')` で展開する。⚠️「たぶん圧縮される」と書かない。
 15. **`upload-pages-artifact` はドット始まりを全部除外し、シンボリックリンクを許さない。**
 16. **`python3 -m http.server` は hook が deny する。** `uv run python -m http.server` を使う。
@@ -220,4 +222,4 @@ Pages に置くのは **重み + 辞書 + Open JTalk + Emscripten ランタイ�
 - **モバイルで測っていない**
 - **ブラウザの音を誰も聴いていない**（G32 と同じ空白）
 - `AudioContext` は 22,050 Hz を直接は保証しない。**リサンプルが挟まるので出音は checksum と一致しない**
-- `.bin` に対する Pages の `Content-Encoding` は未確認（だから `.gz` を置く）
+- ~~`.bin` に対する Pages の `Content-Encoding` は未確認~~ → ✅ **測った**（M-94 §12。gzip が付く）


### PR DESCRIPTION
PR #8 をマージして [`pages.yml`](.github/workflows/pages.yml) が初めて走った直後
（run [33830594650](https://github.com/ayutaz/sanoTTS-jp/actions/runs/33830594650)。build / deploy とも success）に、
**公開 URL を実際に叩いて測った**結果を **M-94 §12** として記録しました。

## 「未確認」が 1 つ埋まりました

計画 §5-14 / §8 と M-94 §10 に **「`.bin` が Pages で gzip されるかは未確認」**と書いていましたが、
測ったら **gzip されます**（`student_i8.bin` は `application/octet-stream` で `content-encoding: gzip`）。

⚠️ **それでも辞書を `.gz` で置く判断は変えていません** — 配信側の方針に依存させないためで、
方針は予告なく変わりうるからです。

## そのほかの実測

| | |
|---|---|
| `.wasm` | **`application/wasm`** で返る → `instantiateStreaming` がそのまま使える |
| `k1_dict.bin.gz` | **5,496,167 B**。⚠️ 手元の `gzip -9`（5,476,122 B）より **20,045 B 大きい** — ubuntu の GNU gzip と Apple gzip の版差。**中身は同じ**（`pages.yml` が展開して `cmp` している） |
| 陽性対照 | 在らざる名前（`saan_web_w8a99.mjs`）は **404**。「全部 200」がサーバの挙動ではないことを確認 |

## ⚠️ これで埋まっていないもの

**「配信されている」ことの確認であって、「ブラウザで動く」ことの確認ではありません。**
**ブラウザは 1 種類も開いていませんし、音も誰も聴いていません**（M-94 §10 はそのまま）。
